### PR TITLE
proof of concept for performing OTR fragmentation during AKE

### DIFF
--- a/src/potr/context.py
+++ b/src/potr/context.py
@@ -288,10 +288,13 @@ class Context(object):
         self.setState(STATE_ENCRYPTED)
 
     def sendFragmented(self, sendPolicy, msg, appdata=None):
+        msg_bytes = bytes(msg)
+
         mms = self.user.maxMessageSize
-        msgLen = len(msg)
-        if mms != 0 and len(msg) > mms and self.policyOtrEnabled() \
-                and self.state == STATE_ENCRYPTED:
+        msgLen = len(msg_bytes)
+        if isinstance(msg, proto.OTRMessage) and mms != 0 and \
+                len(msg_bytes) > mms:
+            msg = msg_bytes
             fms = mms - 19
             fragments = [ msg[i:i+fms] for i in range(0, len(msg), fms) ]
 


### PR DESCRIPTION
This code has not been fully tested and this pull request is just to demonstrate the idea.

When combined with a low enough max message size it solves problems I have had making weechat-otr communicate with some clients (xchat and pidgin IRC).

These clients complain about malformed messages if they get any OTR message split into multiple IRC messages. Since the max message size of IRC is so small OTR setup messages exceed the limit.

Other clients like irssi handle it fine and I made weechat-otr reassemble OTR messages from multiple IRC messages.
