### PR TITLE
Add maxMessageSize() method so it can be overridden in Context subclasses.

### DIFF
--- a/src/potr/context.py
+++ b/src/potr/context.py
@@ -302,7 +302,7 @@ class Context(object):
         self.setState(STATE_ENCRYPTED)
 
     def sendFragmented(self, msg, policy=FRAGMENT_SEND_ALL, appdata=None):
-        mms = self.user.maxMessageSize
+        mms = self.maxMessageSize(appdata)
         msgLen = len(msg)
         if mms != 0 and len(msg) > mms:
             fms = mms - 19
@@ -432,6 +432,10 @@ class Context(object):
             return proto.Error(message[indexBase+7:])
 
         return message
+
+    def maxMessageSize(self, appdata=None):
+        """Return the max message size for this context."""
+        return self.user.maxMessageSize
 
 class Account(object):
     contextclass = Context


### PR DESCRIPTION
This change will let Context subclasses calculate max message size per
context, and possibly even per message based on appdata.

The driver for this is IRC, where the amount of space allowed for the OTR
message depends on the length of the destination nick. The IRC message
would look like:

<pre>
PRIVMSG mmb :?OTR:...
</pre>


Instead of hardcoding a low MMS that accounts for the longest possible
nick a method would allow the context to take the destination nick into account
when calculating MMS.
