### PR TITLE
If PyCrypto is not installed make the error more obvious.

### DIFF
--- a/src/potr/compatcrypto/__init__.py
+++ b/src/potr/compatcrypto/__init__.py
@@ -18,7 +18,4 @@
 
 from potr.compatcrypto.common import *
 
-try:
-    from potr.compatcrypto.pycrypto import *
-except ImportError:
-    from potr.compatcrypto.pure import *
+from potr.compatcrypto.pycrypto import *


### PR DESCRIPTION
A user was getting an error that looked like a problem with pure-python-otr
but the problem was that PyCrypto wasn't installed.
