### PR TITLE
Remove (internal) username message to peer

### DIFF
--- a/src/potr/context.py
+++ b/src/potr/context.py
@@ -505,7 +505,7 @@ class Account(object):
         self.defaultQuery = '?OTRv{versions}?\nI would like to start ' \
                 'an Off-the-Record private conversation. However, you ' \
                 'do not have a plugin to support that.\nSee '\
-                'http://otr.cypherpunks.ca/ for more information.'
+                'https://otr.cypherpunks.ca/ for more information.'
 
     def __repr__(self):
         return '<{cls}(name={name!r})>'.format(cls=self.__class__.__name__,


### PR DESCRIPTION
`context.user.name` is not necessarily meaningful to the other party and may leak information that is not supposed to be public.
