### PR TITLE
reveal used mac keys only once

### DIFF
--- a/src/potr/crypt.py
+++ b/src/potr/crypt.py
@@ -241,6 +241,9 @@ class CryptEngine(object):
         msg = proto.DataMessage(flags, self.ourKeyid-1, self.theirKeyid,
                 long_to_bytes(self.ourDHKey.pub), sess.sendctr.byteprefix(),
                 encmsg, b'', b''.join(self.savedMacKeys))
+
+        self.savedMacKeys = []
+
         msg.mac = SHA1HMAC(sess.sendmac, msg.getMacedData())
         return msg
 


### PR DESCRIPTION
pure-python-otr does not discard old mac keys after it has revealed them. therefore, messages get larger the longer an otr session stays active as more and more mac keys are revealed in the data messages. for weechat-otr, this leads to increasing fragmentation of messages and anti-spam measures being triggered (on ICQ for example). it is also the cause for the infamous bug mmb/weechat-otr#17
