### PR TITLE
add encode('utf-8') accidently removed in 212f19b

### DIFF
--- a/src/potr/context.py
+++ b/src/potr/context.py
@@ -216,7 +216,7 @@ class Context(object):
             if self.state != STATE_ENCRYPTED:
                 self.sendInternal(proto.Error(
                         'You sent encrypted data, but I wasn\'t expecting it.'
-                        ), appdata=appdata)
+                        .encode('utf-8')), appdata=appdata)
                 if ignore:
                     return IGN
                 raise NotEncryptedError(EXC_UNREADABLE_MESSAGE)


### PR DESCRIPTION
this restores compatibility with python3.
fixes afflux/pure-python-otr#50

sorry @mathieui for unnecessarily reintroducing that bug.
