### PR TITLE
Make sure AES key is always 16 bytes.

### DIFF
--- a/src/potr/crypt.py
+++ b/src/potr/crypt.py
@@ -347,7 +347,7 @@ class AuthKeyExchange(object):
         self.lastmsg = None
 
     def startAKE(self):
-        self.r = long_to_bytes(random.getrandbits(128))
+        self.r = long_to_bytes(random.getrandbits(128), 16)
 
         gxmpi = pack_mpi(self.dh.pub)
 


### PR DESCRIPTION
Once in a while the key was less than 16 bytes due to leading zeros
causing pycrypto to raise an exception.

See https://bugs.launchpad.net/pycrypto/+bug/1276431

Bug identified and fix suggested by Legrandin.
