### PR TITLE
Improve compatibility with Python 2.6

### DIFF
--- a/src/potr/proto.py
+++ b/src/potr/proto.py
@@ -123,7 +123,7 @@ class Query(OTRMessage):
     def parse(cls, data):
         if not isinstance(data, bytes):
             raise TypeError('can only parse bytes')
-        udata = data.decode('ascii', errors='replace')
+        udata = data.decode('ascii', 'replace')
 
         versions = set()
         if len(udata) > 0 and udata[0] == '?':


### PR DESCRIPTION
Keyword arguments for `decode` are only supported since 2.7

This was discovered while adding support for python 2.6 to weechat-otr. Other than this one-liner, potr passes all of weechat-otr's tests with `2.6.6` on squeeze, so this may actually be enough reason to do a 1.0.2 release.