### PR TITLE
docs: fix simple typo, compatibilty -> compatibility

### DIFF
--- a/src/potr/__init__.py
+++ b/src/potr/__init__.py
@@ -15,7 +15,7 @@
 #    You should have received a copy of the GNU Lesser General Public License
 #    along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-# some python3 compatibilty
+# some python3 compatibility
 from __future__ import unicode_literals
 
 from potr import context

--- a/src/potr/compatcrypto/common.py
+++ b/src/potr/compatcrypto/common.py
@@ -15,7 +15,7 @@
 #    You should have received a copy of the GNU Lesser General Public License
 #    along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-# some python3 compatibilty
+# some python3 compatibility
 from __future__ import unicode_literals
 
 import logging

--- a/src/potr/context.py
+++ b/src/potr/context.py
@@ -15,7 +15,7 @@
 #    You should have received a copy of the GNU Lesser General Public License
 #    along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-# some python3 compatibilty
+# some python3 compatibility
 from __future__ import unicode_literals
 
 try:

--- a/src/potr/crypt.py
+++ b/src/potr/crypt.py
@@ -15,7 +15,7 @@
 #    You should have received a copy of the GNU Lesser General Public License
 #    along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-# some python3 compatibilty
+# some python3 compatibility
 from __future__ import unicode_literals
 
 import logging

--- a/src/potr/proto.py
+++ b/src/potr/proto.py
@@ -15,7 +15,7 @@
 #    You should have received a copy of the GNU Lesser General Public License
 #    along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-# some python3 compatibilty
+# some python3 compatibility
 from __future__ import unicode_literals
 
 import base64

--- a/src/potr/utils.py
+++ b/src/potr/utils.py
@@ -15,7 +15,7 @@
 #    You should have received a copy of the GNU Lesser General Public License
 #    along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-# some python3 compatibilty
+# some python3 compatibility
 from __future__ import unicode_literals
 
 

--- a/tests/testBasic.py
+++ b/tests/testBasic.py
@@ -1,4 +1,4 @@
-# some python3 compatibilty
+# some python3 compatibility
 from __future__ import print_function
 from __future__ import unicode_literals
 


### PR DESCRIPTION
There is a small typo in src/potr/__init__.py, src/potr/compatcrypto/common.py, src/potr/context.py, src/potr/crypt.py, src/potr/proto.py, src/potr/utils.py, tests/testBasic.py.

Should read `compatibility` rather than `compatibilty`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md